### PR TITLE
Add navigation middleware to page function

### DIFF
--- a/global.php
+++ b/global.php
@@ -166,6 +166,7 @@ function navigationMiddleware ()
 function page ($templateUrl, $actionHandler = null)
 {
   return stack (
+    navigationMiddleware (),
     method ('GET', view ($templateUrl)),
     $actionHandler ? method ('POST', $actionHandler) : null
   );


### PR DESCRIPTION
Navigation was not working because the navigation trail was never computed.